### PR TITLE
feature: sort bookings by date

### DIFF
--- a/src/js/bookings.js
+++ b/src/js/bookings.js
@@ -1,4 +1,4 @@
-import { format } from "date-fns";
+import { compareAsc, compareDesc, format } from "date-fns";
 import { deleteData, pushData } from "./apiCalls";
 import { isCustomer } from "./customers";
 import { isRoom } from "./rooms";
@@ -69,10 +69,18 @@ function findBooking(bookings, bookingID) {
   return bookings.find((booking) => booking.id === bookingID);
 }
 
+function sortBookings(bookings, ascending = true) {
+  const sortAlgorithm = ascending ? compareAsc : compareDesc;
+  return bookings.sort((booking1, booking2) =>
+    sortAlgorithm(booking1.date, booking2.date)
+  );
+}
+
 export {
   addBooking,
   createBooking,
   filterBookings,
   isValidBooking,
   removeBooking,
+  sortBookings,
 };

--- a/test/bookings-test.js
+++ b/test/bookings-test.js
@@ -3,6 +3,7 @@ import {
   createBooking,
   filterBookings,
   isValidBooking,
+  sortBookings,
 } from "../src/js/bookings";
 import { createData } from "../src/js/data";
 import { mockBookings, mockCustomers, mockRooms } from "./mockData";
@@ -197,6 +198,122 @@ describe("Bookings", () => {
           id: "5fwrgu4i7k55hl6tc",
           roomNumber: 4,
           userID: 40,
+        },
+      ]);
+    });
+  });
+
+  describe("Sort bookings", () => {
+    it("Should sort bookings by date in ascending order", () => {
+      const bookings = sortBookings(mockBookings.slice(0, 3), true);
+      expect(bookings).to.deep.equal([
+        {
+          id: "5fwrgu4i7k55hl6t6",
+          userID: 13,
+          date: "2022/01/10",
+          roomNumber: 2,
+        },
+        {
+          id: "5fwrgu4i7k55hl6t5",
+          userID: 21,
+          date: "2022/01/24",
+          roomNumber: 1,
+        },
+        {
+          id: "5fwrgu4i7k55hl6sz",
+          userID: 40,
+          date: "2022/04/22",
+          roomNumber: 1,
+        },
+      ]);
+    });
+
+    it("Should sort more bookings by date in ascending order", () => {
+      const bookings = sortBookings(mockBookings.slice(-3), true);
+      expect(bookings).to.deep.equal([
+        {
+          id: "5fwrgu4i7k55hl6td",
+          userID: 21,
+          date: "2022/01/31",
+          roomNumber: 4,
+        },
+        {
+          id: "5fwrgu4i7k55hl6tb",
+          userID: 12,
+          date: "2022/02/06",
+          roomNumber: 4,
+        },
+        {
+          id: "5fwrgu4i7k55hl6tc",
+          userID: 40,
+          date: "2023/11/30",
+          roomNumber: 4,
+        },
+      ]);
+    });
+
+    it("should have the second parameter default to ascending", () => {
+      const bookings = sortBookings(mockBookings.slice(2, 4));
+      expect(bookings).to.deep.equal([
+        {
+          id: "5fwrgu4i7k55hl6t6",
+          userID: 13,
+          date: "2022/01/10",
+          roomNumber: 2,
+        },
+        {
+          id: "5fwrgu4i7k55hl6t7",
+          userID: 12,
+          date: "2022/02/16",
+          roomNumber: 2,
+        },
+      ]);
+    });
+
+    it("Should sort bookings by date in descending order", () => {
+      const bookings = sortBookings(mockBookings.slice(0, 3), false);
+      expect(bookings).to.deep.equal([
+        {
+          id: "5fwrgu4i7k55hl6sz",
+          userID: 40,
+          date: "2022/04/22",
+          roomNumber: 1,
+        },
+        {
+          id: "5fwrgu4i7k55hl6t5",
+          userID: 21,
+          date: "2022/01/24",
+          roomNumber: 1,
+        },
+        {
+          id: "5fwrgu4i7k55hl6t6",
+          userID: 13,
+          date: "2022/01/10",
+          roomNumber: 2,
+        },
+      ]);
+    });
+
+    it("Should sort more bookings by date in descending order", () => {
+      const bookings = sortBookings(mockBookings.slice(-3), false);
+      expect(bookings).to.deep.equal([
+        {
+          id: "5fwrgu4i7k55hl6tc",
+          userID: 40,
+          date: "2023/11/30",
+          roomNumber: 4,
+        },
+        {
+          id: "5fwrgu4i7k55hl6tb",
+          userID: 12,
+          date: "2022/02/06",
+          roomNumber: 4,
+        },
+        {
+          id: "5fwrgu4i7k55hl6td",
+          userID: 21,
+          date: "2022/01/31",
+          roomNumber: 4,
         },
       ]);
     });


### PR DESCRIPTION
# Description

This adds sorting for bookings. We are using the `date-fns` package to sort the bookings for us. You can see the documentation for [compareAsc](https://date-fns.org/v3.6.0/docs/compareAsc) and [compareDesc](https://date-fns.org/v3.6.0/docs/compareDesc) here. Now we can display the history of a user's bookings in descending order for part bookings, and ascending order for future bookings.

## Type of change

New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

The test for this has been added to `bookings-test.js`. Make sure to run the following command in the terminal:
```js
npm run test
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules